### PR TITLE
Add code owners to the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# List of code owners and reviewers for github.com/google/fswalker.
+
+* @google/cacerts @finfinack


### PR DESCRIPTION
This is so that we can enable 'Require review from Code Owners'
feature in the branch protection rules of the github repo.