### PR TITLE
Use Go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,15 @@ git:
   depth: 3
 language: go
 go:
-  - "1.x"
-  - "1.10.x"
+  - "master"
+  - "1.12.x"
+  - "1.11.x"
+env:
+  global:
+    - GO111MODULE=on
 before_script:
   - go get golang.org/x/lint/golint
+  - go mod download -json
 script:
   - gofmt -d -e -l -s .
   - golint -set_exit_status ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/google/fswalker
+
+go 1.12
+
+require (
+	github.com/golang/protobuf v1.3.1
+	github.com/google/go-cmp v0.3.0
+	github.com/google/uuid v1.1.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Mainly followed examples in https://blog.golang.org/using-go-modules
and ran `go init`. Then:

    $ go test ./...
    go: finding github.com/google/uuid v1.1.1
    go: finding github.com/google/go-cmp/cmp latest
    go: finding github.com/golang/protobuf/proto latest
    go: finding github.com/golang/protobuf/ptypes latest
    go: finding github.com/golang/protobuf/ptypes/timestamp latest
    go: downloading github.com/google/uuid v1.1.1
    go: extracting github.com/google/uuid v1.1.1
    go: finding github.com/google/go-cmp v0.3.0
    go: downloading github.com/google/go-cmp v0.3.0
    go: extracting github.com/google/go-cmp v0.3.0
    go: finding github.com/golang/protobuf v1.3.1
    go: downloading github.com/golang/protobuf v1.3.1
    go: extracting github.com/golang/protobuf v1.3.1
    Loaded file "/tmp/walk.pb786717516" with fingerprint: SHA256(da1b6acdb779c05f4dec6ad7ca8d6b3d32267d285a719888690272b2ce9c1734)

    ok  	github.com/google/fswalker	0.031s
    ?   	github.com/google/fswalker/cmd/reporter	[no test files]
    ?   	github.com/google/fswalker/cmd/walker	[no test files]
    ok  	github.com/google/fswalker/internal/metrics	0.012s
    ?   	github.com/google/fswalker/proto/fswalker	[no test files]

    $ go list -m all
    github.com/google/fswalker
    github.com/golang/protobuf v1.3.1
    github.com/google/go-cmp v0.3.0
    github.com/google/uuid v1.1.1

This also updates Travis CI config to use the last 2 version of Go
releases apart from the tip.

To use modules locally while inside GOPATH dir, set `GO111MODULE`
env variable to `on`.

We might want to tag this with something like "v0.0.1" to mark
the start of Go modules support.