### PR TITLE
ci: always grab updated golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - GO111MODULE=on
 before_script:
-  - go get golang.org/x/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go mod download -json
 script:
   - gofmt -d -e -l -s .


### PR DESCRIPTION
Builds with latest go at head started failing
receintly. This seems to fix the failures.

I suspect Travis CI may already have a golint pre-installed somewhere in a way unsupported by latest go tools so "go get" fails.