### PR TITLE
Add wrapper functions for io operations

### DIFF
--- a/cmd/walker/walker.go
+++ b/cmd/walker/walker.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ var (
 	verbose         = flag.Bool("verbose", false, "when set to true, prints all discovered files including a metadata summary")
 )
 
-func walkCallback(_ context.Context, walk *fspb.Walk) error {
+func walkCallback(ctx context.Context, walk *fspb.Walk) error {
 	if *outputFilePfx == "" {
 		return nil
 	}
@@ -50,7 +49,7 @@ func walkCallback(_ context.Context, walk *fspb.Walk) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(outpath, walkBytes, 0444)
+	return fswalker.WriteFile(ctx, outpath, walkBytes, 0444)
 }
 
 func outputPath(pfx string) (string, error) {

--- a/fswalker.go
+++ b/fswalker.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -69,7 +70,7 @@ func sha256sum(path string) (string, error) {
 
 // readTextProto reads a text format proto buf and unmarshals it into the provided proto message.
 func readTextProto(ctx context.Context, path string, pb proto.Message) error {
-	b, err := ioutil.ReadFile(path)
+	b, err := ReadFile(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -81,5 +82,20 @@ func writeTextProto(ctx context.Context, path string, pb proto.Message) error {
 	blob := proto.MarshalTextString(pb)
 	// replace message boundary characters as curly braces look nicer (both is fine to parse)
 	blob = strings.Replace(strings.Replace(blob, "<", "{", -1), ">", "}", -1)
-	return ioutil.WriteFile(path, []byte(blob), 0644)
+	return WriteFile(ctx, path, []byte(blob), 0644)
+}
+
+// ReadFile reads the file named by filename and returns the contents.
+var ReadFile = func(_ context.Context, filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}
+
+// WriteFile writes data to a file named by filename.
+var WriteFile = func(_ context.Context, filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}
+
+// Glob returns the names of all files matching pattern or nil if there is no matching file.
+var Glob = func(_ context.Context, pattern string) ([]string, error) {
+	return filepath.Glob(pattern)
 }

--- a/reporter.go
+++ b/reporter.go
@@ -20,10 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -120,7 +118,7 @@ func (r *Reporter) fingerprint(b []byte) *fspb.Fingerprint {
 
 // readWalk reads a file as marshaled proto in fspb.Walk format.
 func (r *Reporter) readWalk(ctx context.Context, path string) (*fspb.Walk, *fspb.Fingerprint, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := ReadFile(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -147,7 +145,7 @@ func (r *Reporter) getFile(path string, files []*fspb.File) *fspb.File {
 // It returns the file path it ended up reading, the Walk it read and the fingerprint for it.
 func (r *Reporter) loadLatestWalk(ctx context.Context, hostname, walkPath string) (string, *fspb.Walk, *fspb.Fingerprint, error) {
 	matchpath := path.Join(walkPath, WalkFilename(hostname, time.Time{}))
-	names, err := filepath.Glob(matchpath)
+	names, err := Glob(ctx, matchpath)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/walker_test.go
+++ b/walker_test.go
@@ -37,12 +37,12 @@ import (
 
 type outpathWriter string
 
-func (o outpathWriter) writeWalk(_ context.Context, walk *fspb.Walk) error {
+func (o outpathWriter) writeWalk(ctx context.Context, walk *fspb.Walk) error {
 	walkBytes, err := proto.Marshal(walk)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(string(o), walkBytes, 0444)
+	return WriteFile(ctx, string(o), walkBytes, 0444)
 }
 
 // testFile implements the os.FileInfo interface.
@@ -345,7 +345,7 @@ func TestRun(t *testing.T) {
 		}
 	}
 
-	b, err := ioutil.ReadFile(tmpfile.Name())
+	b, err := ReadFile(ctx, tmpfile.Name())
 	if err != nil {
 		t.Errorf("unable to read file %q: %v", tmpfile.Name(), err)
 	}


### PR DESCRIPTION
Add wrappers for `ReadFile`, `WriteFile` and `Glob` inside `fswalker.go` and adjust the code accordingly.

This makes the library more flexible allowing to change the functions at runtime if needed.