### PR TITLE
Add trailing path separator if it's a directory.

### DIFF
--- a/fswalker.go
+++ b/fswalker.go
@@ -53,6 +53,16 @@ func WalkFilename(hostname string, t time.Time) string {
 	return fmt.Sprintf("%s-%s-fswalker-state.pb", hn, ts)
 }
 
+// NormalizePath returns a cleaned up path with a path separator at the end if it's a directory.
+// It should always be used when printing or comparing paths.
+func NormalizePath(path string, isDir bool) string {
+	p := filepath.Clean(path)
+	if isDir && p[len(p)-1] != filepath.Separator {
+		p += string(filepath.Separator)
+	}
+	return p
+}
+
 // sha256sum reads the given file path and builds a SHA-256 sum over its content.
 func sha256sum(path string) (string, error) {
 	f, err := os.Open(path)

--- a/fswalker_test.go
+++ b/fswalker_test.go
@@ -60,6 +60,33 @@ func TestWalkFilename(t *testing.T) {
 	}
 }
 
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		// arguments
+		path  string
+		isDir bool
+		// expected return value
+		ret string
+	}{
+		{"/a/b", true, "/a/b/"},
+		{"/a/b/", true, "/a/b/"},
+		{"/a/b//", true, "/a/b/"},
+		{"/a/b", false, "/a/b"},
+		{"/a/b/", false, "/a/b"},
+		{"/a/b//", false, "/a/b"},
+		{"/", false, "/"},
+		{"/", true, "/"},
+	}
+	for _, x := range tests {
+		p := filepath.FromSlash(x.path)
+		expected := filepath.FromSlash(x.ret)
+		got := NormalizePath(p, x.isDir)
+		if got != expected {
+			t.Errorf("NormalizePath(%q, %v) = %q; want: %q", p, x.isDir, got, expected)
+		}
+	}
+}
+
 func TestSha256sum(t *testing.T) {
 	gotHash, err := sha256sum(filepath.Join(testdataDir, "hashSumTest"))
 	if err != nil {


### PR DESCRIPTION
This fixes 'exclude_pfx' not excluding the directory itself but only the
files inside. (e.g. 'exclude_pfx: "/proc/"' would still report '/proc' as
changed)
It also makes the report more readable since now it's explicit whether a
path is a directory or a file.
This does not change the generated walk to keep it compatible with the
old ones.