### PR TITLE
Fix generic comparisons on protobuf messages

### DIFF
--- a/fswalker_test.go
+++ b/fswalker_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 
 	fspb "github.com/google/fswalker/proto/fswalker"
@@ -133,7 +134,7 @@ func TestReadTextProtoReviews(t *testing.T) {
 	if err := readTextProto(ctx, filepath.Join(testdataDir, "reviews.asciipb"), reviews); err != nil {
 		t.Errorf("readTextProto() error: %v", err)
 	}
-	diff := cmp.Diff(reviews, wantReviews)
+	diff := cmp.Diff(reviews, wantReviews, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("readTextProto(): unexpected content: diff (-want +got):\n%s", diff)
 	}
@@ -156,7 +157,7 @@ func TestReadTextProtoConfigs(t *testing.T) {
 	if err := readTextProto(ctx, filepath.Join(testdataDir, "defaultReportConfig.asciipb"), config); err != nil {
 		t.Fatalf("readTextProto(): %v", err)
 	}
-	diff := cmp.Diff(config, wantConfig)
+	diff := cmp.Diff(config, wantConfig, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("readTextProto(): unexpected content: diff (-want +got):\n%s", diff)
 	}
@@ -185,7 +186,7 @@ func TestReadPolicy(t *testing.T) {
 		t.Errorf("readTextProto() error: %v", err)
 		return
 	}
-	diff := cmp.Diff(pol, wantPol)
+	diff := cmp.Diff(pol, wantPol, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("readTextProto() policy: diff (-want +got): \n%s", diff)
 	}
@@ -220,7 +221,7 @@ func TestWriteTextProtoReviews(t *testing.T) {
 	if err := readTextProto(ctx, tmpfile.Name(), gotReviews); err != nil {
 		t.Errorf("readTextProto() error: %v", err)
 	}
-	diff := cmp.Diff(gotReviews, wantReviews)
+	diff := cmp.Diff(gotReviews, wantReviews, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("writeTextProto() reviews: diff (-want +got): \n%s", diff)
 	}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -199,9 +198,7 @@ func TestReadWalk(t *testing.T) {
 	if got.Fingerprint.Value != wantFp {
 		t.Errorf("readwalk(): fingerprint value, got=%s, want=%s", got.Fingerprint.Value, wantFp)
 	}
-	diff := cmp.Diff(got.Walk, wantWalk, cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.Contains(p.String(), "XXX_")
-	}, cmp.Ignore()))
+	diff := cmp.Diff(got.Walk, wantWalk, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("readwalk(): content diff (-want +got):\n%s", diff)
 	}

--- a/walker_test.go
+++ b/walker_test.go
@@ -88,7 +88,7 @@ func TestWalkerFromPolicyFile(t *testing.T) {
 		t.Errorf("WalkerFromPolicyFile() error: %v", err)
 		return
 	}
-	diff := cmp.Diff(wlkr.pol, wantPol)
+	diff := cmp.Diff(wlkr.pol, wantPol, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("WalkerFromPolicyFile() policy: diff (-want +got):\n%s", diff)
 	}
@@ -111,7 +111,7 @@ func TestProcess(t *testing.T) {
 			continue
 		}
 	}
-	if diff := cmp.Diff(wlkr.walk.File, files); diff != "" {
+	if diff := cmp.Diff(wlkr.walk.File, files, cmp.Comparer(proto.Equal)); diff != "" {
 		t.Errorf("wlkr.walk.File != files: diff (-want +got):\n%s", diff)
 	}
 }
@@ -293,7 +293,7 @@ func TestConvert(t *testing.T) {
 	}
 
 	gotFile = wlkr.convert(path, info)
-	diff := cmp.Diff(gotFile, wantFile)
+	diff := cmp.Diff(gotFile, wantFile, cmp.Comparer(proto.Equal))
 	if diff != "" {
 		t.Errorf("convert() File proto: diff (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
Generated protobuf messages contain internal data structures
that general purpose comparison functions (e.g., reflect.DeepEqual,
pretty.Compare, etc) do not properly compare. It is already the case
today that these functions may report a difference when two messages
are actually semantically equivalent.

Fix all usages by either calling proto.Equal directly if
the top-level types are themselves proto.Message, or by calling
cmp.Equal with the cmp.Comparer(proto.Equal) option specified.
This option teaches cmp to use proto.Equal anytime it encounters
proto.Message types.