### PR TITLE
Add .gitattributes for Go files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.go	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab diff=golang
+go.mod	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab
+go.sum	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab


### PR DESCRIPTION
Motivation:

It adds git-emitted warnings when staging files that are not properly formatted.